### PR TITLE
revert: restaura API_BASE_URL local em constants

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,11 +10,11 @@
  * 
  * **Ambientes:**
  * - Desenvolvimento: http://localhost:3000/api
- * - Produção: https://mytimetrace.com.br/api
+ * - Produção: https://api.mytimetrace.com
  * 
  * @constant
  */
-export const API_BASE_URL = 'https://mytimetrace.com.br/api';
+export const API_BASE_URL = 'http://localhost:3000/api';
 
 /**
  * Timeout padrão para requisições HTTP (ms)


### PR DESCRIPTION
Este PR reverte a alteração aplicada em `src/config/constants.ts` que apontava `API_BASE_URL` para `https://mytimetrace.com.br/api`.

### O que foi revertido
- `API_BASE_URL` voltou para `http://localhost:3000/api`
- comentário de ambiente de produção voltou para `https://api.mytimetrace.com`

Contexto: correção do conteúdo que entrou no merge anterior para `main`.